### PR TITLE
POC - incorporate Jasmine specs with documentation pipeline

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -25,123 +25,6 @@ Dependencies
 Methods
 -------
 
-### create()
-
-Creates a new object when the deferred promise is resolved
-
-##### Returns
-
-<table>
-<colgroup>
-<col width="50%" />
-<col width="50%" />
-</colgroup>
-<tbody>
-<tr class="odd">
-<td align="left"><a href="">object</a></td>
-<td align="left"><div class="create-page">
-<p>Deferred promise</p>
-</div></td>
-</tr>
-</tbody>
-</table>
-
-### delete(index)
-
-Find `index` and delete it from the API, then remove it from the collection
-
-##### Parameters
-
-<table>
-<colgroup>
-<col width="33%" />
-<col width="33%" />
-<col width="33%" />
-</colgroup>
-<thead>
-<tr class="header">
-<th align="left">Param</th>
-<th align="left">Type</th>
-<th align="left">Details</th>
-</tr>
-</thead>
-<tbody>
-<tr class="odd">
-<td align="left">index</td>
-<td align="left"><a href="">number</a><a href="">object</a></td>
-<td align="left"><div class="delete-page">
-<p>Either the index of the item in the collection to remove, or the object itself, which will be searched for in the collection</p>
-</div></td>
-</tr>
-</tbody>
-</table>
-
-##### Returns
-
-<table>
-<colgroup>
-<col width="50%" />
-<col width="50%" />
-</colgroup>
-<tbody>
-<tr class="odd">
-<td align="left"><a href="">object</a></td>
-<td align="left"><div class="delete-page">
-<p>Promise</p>
-</div></td>
-</tr>
-</tbody>
-</table>
-
-### edit(index)
-
-Find `index` and set it up for editing.
-
-Updates the object when the deferred promise is resolved
-
-##### Parameters
-
-<table>
-<colgroup>
-<col width="33%" />
-<col width="33%" />
-<col width="33%" />
-</colgroup>
-<thead>
-<tr class="header">
-<th align="left">Param</th>
-<th align="left">Type</th>
-<th align="left">Details</th>
-</tr>
-</thead>
-<tbody>
-<tr class="odd">
-<td align="left">index</td>
-<td align="left"><a href="">number</a><a href="">object</a></td>
-<td align="left"><div class="edit-page">
-<p>Either the index of the item in the collection to edit, or the object itself, which will be searched for in the collection</p>
-</div></td>
-</tr>
-</tbody>
-</table>
-
-##### Returns
-
-<table>
-<colgroup>
-<col width="50%" />
-<col width="50%" />
-</colgroup>
-<tbody>
-<tr class="odd">
-<td align="left"><a href="">object</a></td>
-<td align="left"><div class="edit-page">
-<p>Deferred promise</p>
-</div></td>
-</tr>
-</tbody>
-</table>
-
 ### $config()
 
 Get the configuration for this angular-scaffold instance
@@ -183,6 +66,157 @@ Initialise this scaffold
 </tr>
 </tbody>
 </table>
+
+### create()
+
+Creates a new object when the deferred promise is resolved
+
+##### Returns
+
+<table>
+<colgroup>
+<col width="50%" />
+<col width="50%" />
+</colgroup>
+<tbody>
+<tr class="odd">
+<td align="left"><a href="">object</a></td>
+<td align="left"><div class="ur-scaffold-page ur-scaffold-create-page">
+<p>Deferred promise</p>
+</div></td>
+</tr>
+</tbody>
+</table>
+
+#### Specs for ur.scaffold:create
+
+- should return a deferred
+
+- should hang the model instance from the deferred
+
+- should create a new object when the deferred is resolved
+
+- should not save if the save option is false
+
+- should set the saving ui state
+
+### delete(index)
+
+Find `index` and delete it from the API, then remove it from the collection
+
+##### Parameters
+
+<table>
+<colgroup>
+<col width="33%" />
+<col width="33%" />
+<col width="33%" />
+</colgroup>
+<thead>
+<tr class="header">
+<th align="left">Param</th>
+<th align="left">Type</th>
+<th align="left">Details</th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td align="left">index</td>
+<td align="left"><a href="">number</a><a href="">object</a></td>
+<td align="left"><div class="ur-scaffold-page ur-scaffold-delete-page">
+<p>Either the index of the item in the collection to remove, or the object itself, which will be searched for in the collection</p>
+</div></td>
+</tr>
+</tbody>
+</table>
+
+##### Returns
+
+<table>
+<colgroup>
+<col width="50%" />
+<col width="50%" />
+</colgroup>
+<tbody>
+<tr class="odd">
+<td align="left"><a href="">object</a></td>
+<td align="left"><div class="ur-scaffold-page ur-scaffold-delete-page">
+<p>Promise</p>
+</div></td>
+</tr>
+</tbody>
+</table>
+
+#### Specs for ur.scaffold:delete
+
+- should return a deferred
+
+- should hang the model instance from the deferred
+
+- should delete the object when the deferred is resolved
+
+- should set the saving ui state
+
+### edit(index)
+
+Find `index` and set it up for editing.
+
+Updates the object when the deferred promise is resolved
+
+##### Parameters
+
+<table>
+<colgroup>
+<col width="33%" />
+<col width="33%" />
+<col width="33%" />
+</colgroup>
+<thead>
+<tr class="header">
+<th align="left">Param</th>
+<th align="left">Type</th>
+<th align="left">Details</th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td align="left">index</td>
+<td align="left"><a href="">number</a><a href="">object</a></td>
+<td align="left"><div class="ur-scaffold-page ur-scaffold-edit-page">
+<p>Either the index of the item in the collection to edit, or the object itself, which will be searched for in the collection</p>
+</div></td>
+</tr>
+</tbody>
+</table>
+
+##### Returns
+
+<table>
+<colgroup>
+<col width="50%" />
+<col width="50%" />
+</colgroup>
+<tbody>
+<tr class="odd">
+<td align="left"><a href="">object</a></td>
+<td align="left"><div class="ur-scaffold-page ur-scaffold-edit-page">
+<p>Deferred promise</p>
+</div></td>
+</tr>
+</tbody>
+</table>
+
+#### Specs for ur.scaffold:edit
+
+- should return a deferred
+
+- should hang a copy of the model instance from the deferred
+
+- should update the object when the deferred is resolved
+
+- should not update if the save option is false
+
+- should set the saving ui state
 
 ### model()
 

--- a/spec/scaffoldSpec.js
+++ b/spec/scaffoldSpec.js
@@ -1,4 +1,21 @@
-describe("scaffold", function() {
+var smartRep = {
+	map: {},
+	specStarted: function(result) {
+		var description = result.description;
+		var path = result.fullName.replace(description, '').replace(' service ', ':').replace('()', '').trim();
+		if (!smartRep.map[path]) {
+			smartRep.map[path] = [];
+		}
+		smartRep.map[path].push(description);
+	},
+	jasmineDone: function() {
+		console.log(JSON.stringify(smartRep.map, null, 2));
+	}
+};
+
+jasmine.getEnv().addReporter(smartRep);
+
+describe("ur.scaffold", function() {
 	var provider;
 
 	beforeEach(module("ur.scaffold.mocks"));
@@ -296,7 +313,7 @@ describe("scaffold", function() {
 			});
 		});
 
-		describe("create", function() {
+		describe("create()", function() {
 			var s;
 
 			beforeEach(function() {
@@ -365,7 +382,7 @@ describe("scaffold", function() {
 		});
 
 		// @todo: discuss approach to editing/deleting an item. Currently by index.
-		describe("edit", function() {
+		describe("edit()", function() {
 			var s;
 
 			beforeEach(function() {
@@ -443,7 +460,7 @@ describe("scaffold", function() {
 			}));
 		});
 
-		describe("delete", function() {
+		describe("delete()", function() {
 			var s;
 
 			beforeEach(function() {

--- a/src/angular-scaffold.js
+++ b/src/angular-scaffold.js
@@ -251,7 +251,7 @@ angular.module('ur.scaffold', ['ur.model'])
 
 			/**
 			 * @ngdoc function
-			 * @name create
+			 * @name ur.scaffold:create
 			 * @methodOf ur.scaffold
 			 * @description
 			 * Creates a new object when the deferred promise is resolved
@@ -288,7 +288,7 @@ angular.module('ur.scaffold', ['ur.model'])
 
 			/**
 			 * @ngdoc function
-			 * @name edit
+			 * @name ur.scaffold:edit
 			 * @methodOf ur.scaffold
 			 * @param {(number|object)} index Either the index of the item in the collection to edit,
 			 *   or the object itself, which will be searched for in the collection
@@ -329,7 +329,7 @@ angular.module('ur.scaffold', ['ur.model'])
 
 			/**
 			 * @ngdoc function
-			 * @name delete
+			 * @name ur.scaffold:delete
 			 * @methodOf ur.scaffold
 			 * @param {(number|object)} index Either the index of the item in the collection to remove, or the object
 			 *     itself, which will be searched for in the collection


### PR DESCRIPTION
Automatically incorporate Jasmine specs into the documentation

Screenshots
--

<img width="663" alt="screenshot 2015-11-14 14 08 51" src="https://cloud.githubusercontent.com/assets/205245/11163903/41ac2c22-8ad9-11e5-82a9-cfe971ec721f.png">

Why
--

Unit tests are a form of documentation. I decided, therefore, to see if I could build a pipeline which would incorporate the Jasmine specs into generated API documentation in Markdown format, so that people could see everything together at a glance.

How
--
Create a tree from the Jasmine specs (see my Jasmine smartRep reporter in scaffoldSpec.js)
Use the tree inside ngdoc's reader.js to determine which specs are available by matching the full path of the unit test against the full path of the thing being documented. If there is a match, include those specs.

Test script
--

* Browse to https://github.com/radify/angular-scaffold/blob/specs-2-docs/docs/api.md
* Search for "Specs for"
* **Assert that** the unit tests that correspond to the create, delete and edit methods on angular-scaffold have lists of specs

Secret special sauce
--

Hacky HTML->MD script:

```bash
 gulp ngdocs && pushd build/docs/partials/api ; for f in *.html; do echo "Processing $f file..";  pandoc $f -f html -t markdown_github  -o ../../../../docs/${f/html/md}  ;  done ; popd ; pushd docs ; echo "# angular-scaffold API documentation\n\n" > api.tmp ; cat *.md  >> api.tmp ; rm *md ; mv api.tmp api.md && sed -i .bak 's/ prettyprint/javascript/' api.md && rm api.md.bak && popd
```

Also, I had to make some tiny modifications to `gulp-angular` to do this). If people think this is a good approach, I can fork `gulp-angular` and build a solid pipeline around all of this tooling.

Thanks,
- Gavin

