### PR TITLE
First release fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+
+## [0.3.1] - 2015-11-30
+### Fixed
+- `README`
+- `CHANGELOG`
+
+## [0.3.0] - 2015-11-30
 ### Added
 - Thorough documentation
 - A sample project
@@ -46,6 +53,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [0.1.0] - 2015-08-11
 - Initial Release
 
-[Unreleased]: https://github.com/radify/angular-scaffold/compare/0.2.0...HEAD
+[Unreleased]: https://github.com/radify/angular-scaffold/compare/0.3.1...HEAD
+[0.3.1]: https://github.com/radify/angular-scaffold/compare/0.3.0...0.3.1
+[0.3.0]: https://github.com/radify/angular-scaffold/compare/0.2.0...0.3.0
 [0.2.0]: https://github.com/radify/angular-scaffold/compare/0.1.1...0.2.0
 [0.1.1]: https://github.com/radify/angular-scaffold/compare/0.1.0...0.1.1

--- a/README.md
+++ b/README.md
@@ -4,22 +4,18 @@
 [![devDependency Status](https://david-dm.org/radify/angular-scaffold/dev-status.svg)](https://david-dm.org/radify/angular-scaffold#info=devDependencies)
 [![Code Climate](https://codeclimate.com/github/radify/angular-scaffold/badges/gpa.svg)](https://codeclimate.com/github/radify/angular-scaffold)
 
-Angular Scaffold
-==
+# Angular Scaffold
 
-Description
---
+## Simple scaffolding for AngularJS
 
-Angular Scaffold is a collection of convenience wrappers around angular-model collections.
+**Angular Scaffold** is a collection of convenience wrappers around angular-model collections.
 
-Dependencies
---
+## Dependencies
 
 * [AngularJS](https://angularjs.org/)
 * [Angular Model](https://www.npmjs.com/package/angular-model)
 
-Running unit tests
---
+## Running unit tests
 
 Install the test runner with npm:
 
@@ -39,13 +35,11 @@ You can run coverage with:
 gulp coverage
 ```
 
-angular-scaffold API docs
---
+## angular-scaffold API docs
 
 See [/docs/api.md](/docs/api.md) in this project for detailed documentation of all angular-scaffold's functions.
 
-Supporting angular-scaffold in your API
---
+## Supporting angular-scaffold in your API
 
 Your API must:
 
@@ -68,8 +62,7 @@ Your API must:
 ]
 ```
 
-Basic Usage
---
+## Basic Usage
 
 In your AngularJS application, include the JavaScript:
 
@@ -98,8 +91,7 @@ Example controller using Angular Scaffold:
 })
 ```
 
-Basic CRUD example project
---
+## Basic CRUD example project
 
 An [example application is included in this repository](/sample-project/). It has a very simple API that illustrates a basic use case for angular-scaffold.
 
@@ -113,8 +105,7 @@ node server.js
 
 You can then browse to http://localhost:4730/ and add/remove Post objects from a list. angular-scaffold takes care of talking to the API for you.
 
-Pagination
---
+## Pagination
 
 angular-scaffold can paginate your model. Your API will need to support the `Range: resources=n-n` header to take advantage of this. For example, `Range: resources=10-20` would return resources 10 through 20.
 
@@ -124,8 +115,7 @@ paginate: { size: 20, page: 1, strategy: 'paged' }
 });
 ```
 
-Querying
---
+## Querying
 
 You can pass a specific query in, which will be sent through to the API. Your API will have to know how to respond to this.
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "angular-scaffold",
   "description:": "Angular Scaffold is a collection of convenience wrappers around angular-model collections.",
   "license": "BSD-3-Clause",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "homepage": "https://github.com/radify/angular-scaffold/",
   "repository": {
     "type": "git",


### PR DESCRIPTION
First release fixes
--

### Description

* For some reason, [NPM](https://www.npmjs.com/package/angular-scaffold) does not like our current `README` format. It doubles a couple of badges.
![image](https://cloud.githubusercontent.com/assets/590520/11481505/d0391916-976b-11e5-87b4-75823fa2fe65.png)
* This PR reformats the `README` so that it works on NPM. 
* Additionally, the `CHANGELOG` was not updated for the release, and this PR corrects that. 
* Please note that this bumps the release number to `0.3.1`. This is necessary in order to publish the changes to NPM. 

### Test Script

* None